### PR TITLE
Use goreleaserbot as tap commit author

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,8 +37,8 @@ homebrew_casks:
       branch: master
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     commit_author:
-      name: Taras Drapalyuk
-      email: taras@drapalyuk.com
+      name: goreleaserbot
+      email: bot@goreleaser.com
     commit_msg_template: "Brew cask update for `{{ .ProjectName }}` version `{{ .Tag }}`"
     homepage: "https://github.com/kulapard/gol"
     description: "Terminal version of Conway's Game of Life written in Go"


### PR DESCRIPTION
## What

Author the Homebrew cask commits goreleaser pushes to `kulapard/homebrew-tap` as **`goreleaserbot <bot@goreleaser.com>`** (goreleaser's default bot identity, per https://goreleaser.com/customization/publish/homebrew_casks/) instead of a personal author.

## Change

`.goreleaser.yaml` → `homebrew_casks[].commit_author`: `Taras Drapalyuk` → `goreleaserbot`.

Cosmetic only — affects who authors the auto-generated cask-update commits in the tap. Push auth still uses `HOMEBREW_TAP_GITHUB_TOKEN`.

Validated with `goreleaser check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)